### PR TITLE
fix: SSL verification and escape sequence issues

### DIFF
--- a/lib/scanner.py
+++ b/lib/scanner.py
@@ -1,4 +1,3 @@
-
 import sys;
 import requests;
 import urllib;
@@ -85,12 +84,12 @@ class Scanner():
             for param in data:
                 data[param] = urllib.parse.quote(data[param]);
             strData = self.implodeData(data);
-            req = session.get(self.url + "?" + strData,headers=self.headers,cookies=self.cookies,allow_redirects=False);
+            req = session.get(self.url + "?" + strData,headers=self.headers,cookies=self.cookies,allow_redirects=False, verify=False);
         elif self.method == "post":
-            req = session.post(self.url,data,headers=self.headers,cookies=self.cookies,allow_redirects=False);
+            req = session.post(self.url,data,headers=self.headers,cookies=self.cookies,allow_redirects=False, verify=False);
         elif self.method == "json":
             #print("DEBUG:",data);
-            req = session.post(self.url, json=data);
+            req = session.post(self.url, json=data, verify=False);
         
         return req;
                 
@@ -163,4 +162,3 @@ class Scanner():
         #except Exception as err:
             #print(err);
             #return False;
-        

--- a/tests/regexArrayBlindInjection.py
+++ b/tests/regexArrayBlindInjection.py
@@ -113,7 +113,7 @@ passwords with:");
 ##        return self.fromVarToString(var);
 
     def grabWord(self,length):
-        charset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!\\\"#$%&'._()*+,-/:;<=>?@{|}[\]^`~"
+        charset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!\"#$%&'._()*+,-/:;<=>?@{|}[\\]^`~"
         var = [];
         while len(self.fromVarToString(var)) < length:
             prev = len(var);


### PR DESCRIPTION
This PR addresses two issues:

1. SSL Certificate Verification Error
- Added `verify=False` option to requests to handle SSL certificate verification errors
- This allows the tool to work with sites that have self-signed or invalid SSL certificates

2. Invalid Escape Sequence Warning
- Fixed invalid escape sequence in charset string in regexArrayBlindInjection.py
- Properly escaped special characters in the charset string

These changes improve the tool's functionality when testing sites with SSL certificate issues while maintaining the original functionality.